### PR TITLE
Version 3 of twilio library no longer has this call

### DIFF
--- a/lambda-functions/receive-vote/app.js
+++ b/lambda-functions/receive-vote/app.js
@@ -25,7 +25,7 @@ exports.handler = function(event, context) {
         console.log(err);
         context.fail(err);
       } else {
-        var resp = new twilio.TwimlResponse();
+        var resp = new twilio.twiml.MessagingResponse();
         resp.message("Thank you for casting a vote for " + votedFor);
         context.done(null, [resp.toString()]);
         console.log("Vote received for %s", votedFor);


### PR DESCRIPTION
Revise with new equivalent of function that used to exist in Twilio's 2.0 library, with the renamed version that instead exists in Twilio's 3.0 library... which is the library that users of this repo will get if they ever `npm update` or `npm install` while working with the `receive-vote` lambda function source code.